### PR TITLE
OR-3599 work around threads error

### DIFF
--- a/apriltag_pywrap.c
+++ b/apriltag_pywrap.c
@@ -245,10 +245,10 @@ static PyObject* apriltag_detect(apriltag_py_t* self,
     zarray_t* detections = apriltag_detector_detect(self->td, &im);
     int N = zarray_size(detections);
 
-    if (N == 0 && errno == EAGAIN){
-        PyErr_Format(PyExc_RuntimeError, "Unable to create %d threads for detector", self->td->nthreads);
-        goto done;
-    }
+    //if (N == 0 && errno == EAGAIN){
+    //    PyErr_Format(PyExc_RuntimeError, "Unable to create %d threads for detector", self->td->nthreads);
+    //    goto done;
+    //}
 
     detections_tuple = PyTuple_New(N);
     if(detections_tuple == NULL)


### PR DESCRIPTION
It's unclear where this error comes from, however, it doesn't seem to be actually crucial. I tested locally with a lot of crops in scope of a project investigation and detection worked fine
see related https://github.com/AprilRobotics/apriltag/issues/230